### PR TITLE
Catch exception in Solution generation

### DIFF
--- a/Spartacus/Modes/DLL/ModeDLL.cs
+++ b/Spartacus/Modes/DLL/ModeDLL.cs
@@ -98,7 +98,14 @@ namespace Spartacus.Modes.DLL
 
                 if (String.IsNullOrEmpty(file.Value) || String.IsNullOrEmpty(dllFile) || !File.Exists(dllFile))
                 {
-                    File.Create(Path.Combine(solution, file.Key + "-file-not-found")).Dispose();
+                    try
+                    {
+                        File.Create(Path.Combine(solution, file.Key + "-file-not-found")).Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Warning(" - error creating", false, false);
+                    }
                     Logger.Warning(" - No DLL Found", true, false);
                     continue;
                 }


### PR DESCRIPTION
Exception is not handled when file is not found or there is error in creating file. It stops creating all solutions after this unhandled exception with following error:

`[07:08:37] Processing logfile64.dll[07:08:37] Could not find a part of the path 'C:\spartacus\logfile64.dll-file-not-found'.`

Fix catches exception, so only solution which have error is not built. Building of other solution continues.